### PR TITLE
Fix ModuleDataTransmitter not being linked to the ModuleDeployableAntenna

### DIFF
--- a/files/ju1mda.cfg
+++ b/files/ju1mda.cfg
@@ -66,6 +66,7 @@ PART
 		packetSize = 4
 		packetResourceCost = 22.0
 		requiredResource = ElectricCharge
+		DeployFxModules = 0 // index of the ModuleDeployableAntenna module
 		antennaPower = 300000000000
 		antennaCombinable = True
 	}

--- a/files/jw1mda.cfg
+++ b/files/jw1mda.cfg
@@ -73,6 +73,7 @@ PART
 		packetSize = 4
 		packetResourceCost = 18.0
 		requiredResource = ElectricCharge
+		DeployFxModules = 1 // index of the ModuleDeployableAntenna module
 		antennaPower = 300000000000
 		antennaCombinable = True
 	}

--- a/files/jx2lda.cfg
+++ b/files/jx2lda.cfg
@@ -73,6 +73,7 @@ PART
 		packetSize = 4
 		packetResourceCost = 22.0
 		requiredResource = ElectricCharge
+		DeployFxModules = 1 // index of the ModuleDeployableAntenna module
 		antennaPower = 1000000000000
 		antennaCombinable = True
 	}


### PR DESCRIPTION
Fix ModuleDataTransmitter not being linked to the ModuleDeployableAntenna.
This allow ModuleDataTransmitter to control the animation and prevent having a connection or being able to transmit when the antenna isn't deployed.